### PR TITLE
Set minimum SDK version to 23

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,7 +19,7 @@ android {
     buildToolsVersion "25.0.0"
     defaultConfig {
         applicationId "com.pspdfkit.labs.quickdemo"
-        minSdkVersion 24
+        minSdkVersion 23
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
## Resolves #3

This PR reduces the minimum SDK version to 23 allowing to use the app on Marshmallow devices.