### PR TITLE
Android Studio 3.0 Support

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,8 +16,8 @@ apply plugin: 'kotlin-android'
 apply plugin: 'android-command'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.0"
+    compileSdkVersion 26
+    buildToolsVersion "26.0.2"
     defaultConfig {
         applicationId "com.pspdfkit.labs.quickdemo"
         minSdkVersion 23
@@ -43,8 +43,8 @@ dependencies {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    compile 'com.android.support:appcompat-v7:25.0.0'
-    compile 'com.android.support:support-v4:25.0.0'
+    compile 'com.android.support:appcompat-v7:26.1.0'
+    compile 'com.android.support:support-v4:26.1.0'
 
     compile 'io.reactivex.rxjava2:rxjava:2.0.0'
     compile 'io.reactivex.rxjava2:rxandroid:2.0.0'

--- a/app/src/main/kotlin/com/pspdfkit/labs/quickdemo/activity/SetupGuideActivity.kt
+++ b/app/src/main/kotlin/com/pspdfkit/labs/quickdemo/activity/SetupGuideActivity.kt
@@ -43,7 +43,7 @@ class SetupGuideActivity : AppCompatActivity() {
 
         // Setup content is just informative. We're using a webview to show pre-formatted instructions.
         setContentView(R.layout.activity_setup_guide)
-        val webView = findViewById(R.id.webview) as WebView
+        val webView: WebView = findViewById(R.id.webview)
         webView.loadUrl("file:///android_asset/setup-guide.html")
 
         // We periodically check if the permission has been granted. Once this happened, we notify the user and finish the activity.

--- a/build.gradle
+++ b/build.gradle
@@ -12,14 +12,15 @@
  */
 
 buildscript {
-    ext.kotlin_version = '1.0.5'
+    ext.kotlin_version = '1.1.51'
 
     repositories {
         jcenter()
+        google()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.2'
+        classpath 'com.android.tools.build:gradle:3.0.0-rc1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.novoda:gradle-android-command-plugin:1.6.2'
     }
@@ -28,6 +29,7 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -11,9 +11,9 @@
 #   This notice may not be removed from this file
 #
 
-#Mon Dec 28 10:00:20 PST 2015
+#Mon Oct 16 10:43:14 EDT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip


### PR DESCRIPTION
Updates build tools, plugins, etc to Android Studio 3.0-compatible versions. Fixes an issue with Kotlin 1.1 type inference and WebView.