### PR TITLE
Adds powersave demo option

### DIFF
--- a/app/src/main/kotlin/com/pspdfkit/labs/quickdemo/DemoMode.kt
+++ b/app/src/main/kotlin/com/pspdfkit/labs/quickdemo/DemoMode.kt
@@ -261,6 +261,13 @@ class DemoMode private constructor(context: Context) {
         var plugged by booleanPreference("batteryPlugged", false) { value ->
             if (enabled) sendDemoCommand("battery", "plugged" to value)
         }
+
+        /**
+         * Enables or disables the device's power save mode. Defaults to `false`.
+         */
+        var powersave by booleanPreference("batteryPowersave", default = false) { value ->
+            if(enabled) sendDemoCommand("battery", "powersave" to value)
+        }
     }
 
     private fun sendDemoCommand(command: String, vararg extras: Pair<String, Any>) {

--- a/app/src/main/kotlin/com/pspdfkit/labs/quickdemo/DemoMode.kt
+++ b/app/src/main/kotlin/com/pspdfkit/labs/quickdemo/DemoMode.kt
@@ -266,7 +266,7 @@ class DemoMode private constructor(context: Context) {
          * Enables or disables the device's power save mode. Defaults to `false`.
          */
         var powersave by booleanPreference("batteryPowersave", default = false) { value ->
-            if(enabled) sendDemoCommand("battery", "powersave" to value)
+            if (enabled) sendDemoCommand("battery", "powersave" to value)
         }
     }
 

--- a/app/src/main/res/xml/demo_mode_preferences.xml
+++ b/app/src/main/res/xml/demo_mode_preferences.xml
@@ -44,6 +44,11 @@
             android:defaultValue="false"
             android:key="batteryPlugged"
             android:title="Show battery as charging" />
+
+        <SwitchPreference
+            android:defaultValue="false"
+            android:key="batteryPowersave"
+            android:title="Powersave mode" />
     </PreferenceCategory>
 
 


### PR DESCRIPTION
This PR introduces the missing `powersave` demo option for the battery indicator:

![image](https://user-images.githubusercontent.com/1101857/69425015-555a7300-0d2a-11ea-9469-8ae35bf64e29.png)
